### PR TITLE
Gradle plugin test branch

### DIFF
--- a/app/build-with-flavours.gradle
+++ b/app/build-with-flavours.gradle
@@ -5,9 +5,9 @@ apply plugin: "com.browserstack.gradle"
 
 buildscript {
     repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
+//        maven {
+//            url "https://plugins.gradle.org/m2/"
+//        }
         mavenLocal()
         mavenCentral()
     }
@@ -15,7 +15,7 @@ buildscript {
     dependencies {
         classpath 'com.stanfy.spoon:spoon-gradle-plugin:1.2.2'
       //  classpath "gradle.plugin.com.browserstack.gradle:browserstack-gradle-plugin:3.0.3"
-        classpath "com.browserstack:gradle:3.0.3-u3x"
+        classpath "com.browserstack:gradle:3.0.4"
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,9 +8,9 @@ jacoco {
 }
 buildscript {
     repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
+//        maven {
+//            url "https://plugins.gradle.org/m2/"
+//        }
         mavenLocal()
         mavenCentral()
     }
@@ -18,7 +18,7 @@ buildscript {
     dependencies {
         classpath 'com.stanfy.spoon:spoon-gradle-plugin:1.2.2'
      //   classpath "gradle.plugin.com.browserstack.gradle:browserstack-gradle-plugin:3.0.3"
-        classpath "com.browserstack:gradle:3.0.3-u3x"
+        classpath "com.browserstack:gradle:3.0.4"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,14 @@
 buildscript {
 
     repositories {
-        google()
+     //   google()
+        maven { url 'https://maven.google.com' }
         jcenter()
+     //   mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
-        //classpath 'com.android.tools.build:gradle:3.4.1'
+       // classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -16,8 +18,10 @@ buildscript {
 
 allprojects {
     repositories {
-        google()
+     //   google()
+        maven { url 'https://maven.google.com' }
         jcenter()
+     //   mavenCentral()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Nov 08 15:53:49 IST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip


### PR DESCRIPTION
Following changes incorporated - 

1. Updated gradle plugin version to 3.4.1 from 2.3.0
2. Updated distributionUrl in gradle-wrapper.properties.
3. Removed  maven { url "https://plugins.gradle.org/m2/"} in app/build.gradle and app/build-with-flavors.gradle.
4. Bumped version to 3.0.4 in app/build.gradle and app/build-with-flavors.gradle